### PR TITLE
chore(deps): adopt shared renovate-config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>eddgrant/renovate-config"]
+}


### PR DESCRIPTION
## Summary
- Adopts the shared Renovate preset at [`eddgrant/renovate-config`](https://github.com/eddgrant/renovate-config).
- This repo previously had no Renovate config.

Inherited behaviours: 21-day release-age gate, security alerts bypass the gate, dependency-dashboard issue, ecosystem groupings (Kotlin / Micronaut / Next.js+React / TypeScript / Terraform / GitHub Actions / etc.), `chore(deps): …` semantic-commit prefixes, monthly lockfile maintenance, no automerge by default.

## Test plan
- [ ] After merge, Renovate creates a Dependency Dashboard issue and opens PRs for any deps that already clear the 21-day age window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)